### PR TITLE
Fix the configuration of the service

### DIFF
--- a/DependencyInjection/CompilerPath/Authentication.php
+++ b/DependencyInjection/CompilerPath/Authentication.php
@@ -4,6 +4,7 @@ namespace Anyx\LoginGateBundle\DependencyInjection\CompilerPath;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 class Authentication implements CompilerPassInterface
 {
@@ -18,13 +19,13 @@ class Authentication implements CompilerPassInterface
                     ->addMethodCall(
                             'setBruteForceChecker',
                             array(
-                                $container->findDefinition('anyx.login_failure.brute_force_checker')
+                                new Reference('anyx.login_failure.brute_force_checker')
                             )
                     )
                     ->addMethodCall(
                             'setDispatcher',
                             array(
-                                $container->findDefinition('event_dispatcher')
+                                new Reference('event_dispatcher')
                             )
                     )
                 


### PR DESCRIPTION
Getting the service definition and injecting it as argument will make Symfony inject a new instance defined the same way instead of using the same service instance.

Using a reference is the proper way