### PR TITLE
Clean the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,10 @@
             "email": "alx.devel@gmail.com"
         }
     ],
-    "source": {
-        "type": "git",
-        "url": "https://github.com/anyx/LoginGateBundle.git",
-        "reference": "master"
-    },
     "require": {
         "symfony/framework-bundle": "2.*"
     },
-    "target-dir": "Anyx/LoginGateBundle",
     "autoload": {
-        "psr-0": { "Anyx\\LoginGateBundle": "" }
+        "psr-4": { "Anyx\\LoginGateBundle\\": "" }
     }
 }


### PR DESCRIPTION
- remove the source info, as Packagist is getting them from the VCS metadata anyway and will ignore whatever is set there
- use PSR-4 rather than the legacy target-dir setting