### PR TITLE
Store ip as string

### DIFF
--- a/Document/FailureLoginAttemptRepository.php
+++ b/Document/FailureLoginAttemptRepository.php
@@ -14,10 +14,6 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
      */
     public function getCountAttempts($ip, \DateTime $startDate)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-
         return $this->createQueryBuilder()
             ->field('ip')->equals($ip)
             ->field('createdAt')->gt($startDate)
@@ -26,15 +22,11 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
 
     /**
      *
-     * @param integer $ip
+     * @param string $ip
      * @return \Anyx\LoginGateBundle\Model\FailureLoginAttempt | null
      */
     public function getLastAttempt($ip)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-
         return $this->createQueryBuilder()
             ->field('ip')->equals($ip)
             ->sort('createdAt', 'desc')
@@ -44,15 +36,11 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
 
     /**
      *
-     * @param integer $ip
+     * @param string $ip
      * @return integer
      */
     public function clearAttempts($ip)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-
         return $this->createQueryBuilder()
             ->remove()
             ->field('ip')->equals($ip)

--- a/Entity/FailureLoginAttemptRepository.php
+++ b/Entity/FailureLoginAttemptRepository.php
@@ -14,10 +14,6 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
      */
     public function getCountAttempts($ip, \DateTime $startDate)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-        
         return $this->createQueryBuilder('attempt')
                     ->select('COUNT(attempt.id)')
                     ->where('attempt.ip = :ip')
@@ -32,14 +28,11 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
     
     /**
      * 
-     * @param integer $ip
+     * @param string $ip
      * @return \Anyx\LoginGateBundle\Entity\FailureLoginAttempt | null
      */
     public function getLastAttempt($ip)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
         return $this->createQueryBuilder('attempt')
                     ->where('attempt.ip = :ip')
                     ->orderBy('attempt.createdAt', 'DESC')
@@ -53,18 +46,14 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
     }
     
     /**
-     * @param integer $ip
+     * @param string $ip
      * @return integer
      */
     public function clearAttempts($ip)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-        
         return $this->getEntityManager()
-                ->createQuery('DELETE FROM ' . $this->getClassMetadata()->name . ' attempt WHERE attempt.ip = ' . intval($ip))
-                ->execute()
+                ->createQuery('DELETE FROM ' . $this->getClassMetadata()->name . ' attempt WHERE attempt.ip = :ip')
+                ->execute(['ip' => $ip])
             ;
     }
 }

--- a/Model/FailureLoginAttempt.php
+++ b/Model/FailureLoginAttempt.php
@@ -10,7 +10,7 @@ abstract class FailureLoginAttempt
     protected $id;
 
     /**
-     * @var int
+     * @var string
      */
     protected $ip;
 
@@ -36,15 +36,11 @@ abstract class FailureLoginAttempt
 
     public function getIp()
     {
-        return long2ip($this->ip);
+        return $this->ip;
     }
 
     public function setIp($ip)
     {
-        if (!is_int($ip)) {
-            $ip = ip2long($ip);
-        }
-
         $this->ip = $ip;
     }
 

--- a/Model/FailureLoginAttemptRepositoryInterface.php
+++ b/Model/FailureLoginAttemptRepositoryInterface.php
@@ -12,13 +12,13 @@ interface FailureLoginAttemptRepositoryInterface
     public function getCountAttempts($ip, \DateTime $startDate);
 
     /**
-     * @param integer $ip
+     * @param string $ip
      * @return \Anyx\LoginGateBundle\Model\FailureLoginAttempt | null
      */
     public function getLastAttempt($ip);
 
     /**
-     * @param integer $ip
+     * @param string $ip
      * @return integer
      */
     public function clearAttempts($ip);

--- a/Resources/config/doctrine/FailureLoginAttempt.mongodb.yml
+++ b/Resources/config/doctrine/FailureLoginAttempt.mongodb.yml
@@ -6,7 +6,7 @@ Anyx\LoginGateBundle\Document\FailureLoginAttempt:
             type: id
             id: true
         ip:
-            type: integer
+            type: string
             index: true
         createdAt:
             type: date

--- a/Resources/config/doctrine/FailureLoginAttempt.orm.yml
+++ b/Resources/config/doctrine/FailureLoginAttempt.orm.yml
@@ -11,7 +11,8 @@ Anyx\LoginGateBundle\Entity\FailureLoginAttempt:
             generator: { strategy: AUTO }
     fields:
         ip:
-            type: integer
+            type: string
+            length: 45 #compatibility with ipv6
         createdAt:
             type: datetime
         data:


### PR DESCRIPTION
Because ip as int has problems:
- ip can be negative on 32 bit system
- not compatible with ipv6
- $ip is int or string. It is not obviously and makes some errors