### PR TITLE
Implemented getMessageKey() method

### DIFF
--- a/Exception/BruteForceAttemptException.php
+++ b/Exception/BruteForceAttemptException.php
@@ -6,5 +6,11 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class BruteForceAttemptException extends AuthenticationException
 {
-    
+    /**
+     * @return string
+     */
+    public function getMessageKey()
+    {
+        return 'Too many authentication failures.';
+    }
 }


### PR DESCRIPTION
Fixes #14

---

The exception should have it's own implementation of `getMessageKey()` to return a string uniquely identifyable and translatable.

---

Changes:  
Added `getMessageKey()` method that returns the message 'Too many authentication failures.'

---

HowToTest: (Tested with FOSUB)  
Brute force attempt should not show the message 'An authentication exception occurred.'. Instead it should show the message 'Too many authentication failures.'