### PR TITLE
Filter by username only if defined

### DIFF
--- a/Entity/FailureLoginAttemptRepository.php
+++ b/Entity/FailureLoginAttemptRepository.php
@@ -19,9 +19,7 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
                 'createdAt' => $startDate,
             ]);
 
-        if (!$username) {
-            $queryBuilder->andWhere('attempt.username IS NULL');
-        } else {
+        if ($username) {
             $queryBuilder->andWhere('attempt.username = :username')->setParameter('username', $username);
         }
 
@@ -39,9 +37,7 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
                 'ip' => $ip,
             ]);
 
-        if (!$username) {
-            $queryBuilder->andWhere('attempt.username IS NULL');
-        } else {
+        if ($username) {
             $queryBuilder->andWhere('attempt.username = :username')->setParameter('username', $username);
         }
 
@@ -56,9 +52,7 @@ class FailureLoginAttemptRepository extends Repository implements FailureLoginAt
         $sql = 'DELETE FROM %s attempt WHERE attempt.ip = :ip';
         $parameters = ['ip' => $ip];
 
-        if (!$username) {
-            $sql .= ' AND attempt.username IS NULL';
-        } else {
+        if ($username) {
             $sql .= ' AND attempt.username = :username';
             $parameters['username'] = $username;
         }


### PR DESCRIPTION
In `AuthenticationFailureEvent` handler, `LoginFormUsernameResolver ` returns the parameter  `_username` in the request, this value is inserted into the database. But in all other requests, this parameter may not exist, so `canLogin` method in `BruteForceChecker` always returns `true` because `FailureLoginAttemptRepository` filters records with null username.

I think `FailureLoginAttemptRepository` should filter by `ip` and `username` only if `username` is defined, if not, filter by `ip` only.