### PR TITLE
Check if session exists in DB Storage

### DIFF
--- a/Storage/DatabaseStorage.php
+++ b/Storage/DatabaseStorage.php
@@ -96,7 +96,7 @@ class DatabaseStorage implements StorageInterface
         $data = [
             'exception' => $exception->getMessage(),
             'clientIp' => $request->getClientIp(),
-            'sessionId' => $request->getSession()->getId(),
+            'sessionId' => $request->hasSession() ? $request->getSession()->getId() : null,
         ];
 
         $model->setData($data);


### PR DESCRIPTION
In order to be able to use this bundle in a stateless application we need to make sure that the DB storage works even if session is not initialised